### PR TITLE
Retreive a longitude-based timezone from GlobalPosition

### DIFF
--- a/src/pos.rs
+++ b/src/pos.rs
@@ -36,4 +36,17 @@ impl GlobalPosition {
         self.lng_hour
     }
 
+    /// Returns a [FixedOffset] timezone calculated from
+    /// this location's longitude
+    ///
+    /// [FixedOffset]: chrono::FixedOffset
+    pub fn lng_timezone(&self) -> chrono::FixedOffset {
+        const SECS_IN_HOUR: f64 = 3600_f64;
+        if self.lng() >= 0_f64 {
+            chrono::FixedOffset::east((self.lng_hour.abs() * SECS_IN_HOUR) as i32)
+        } else {
+            chrono::FixedOffset::west((self.lng_hour.abs() * SECS_IN_HOUR) as i32)
+        }
+    }
+
 }


### PR DESCRIPTION
Hi! Thanks for the lib!
I'd like to add a method to `GlobalPosition` that would return a "longitude timezone" of this location.
Our use-case is: having a current UTC timestamp and an arbitrary location, get a local solar time and sunset/sunrise solar time for this location. (The potential difference in the dates doesn't really matter)

Something like:
```
    fn example() {
        // GMT 06/09/2022 22:00
        let utc_now = Utc.timestamp(1662501600, 0);
        // it's 07/09/2022 07:00 in Tokyo
        let tokyo = GlobalPosition::at(35.68626450271698, 139.79851780632603);

        let tokyo_now_solar = utc_now.with_timezone(&tokyo.lng_timezone()).time();
        let tokyo_sunrise_solar = circadia::time_of_event(utc_now.date(), &tokyo, circadia::SunEvent::SUNRISE)
            .unwrap()
            .with_timezone(&tokyo.lng_timezone())
            .time();
        let tokyo_sunset_solar = circadia::time_of_event(utc_now.date(), &tokyo, circadia::SunEvent::SUNSET)
            .unwrap()
            .with_timezone(&tokyo.lng_timezone())
            .time();

        println!("{}", utc_now.time());
        println!("{}", tokyo_now_solar);
        println!("{}", tokyo_sunrise_solar);
        println!("{}", tokyo_sunset_solar);
        
        /*
        Prints:
        22:00:00
        07:19:11
        05:35:07
        18:21:25
         */
    }
```